### PR TITLE
Add create_from function

### DIFF
--- a/.github/workflows/indent.yml
+++ b/.github/workflows/indent.yml
@@ -22,8 +22,8 @@ jobs:
 
       - name: Fetch PostgreSQL sources
         run: |
-          git clone https://github.com/postgres/postgres --branch REL_15_STABLE --single-branch 
-          cd postgres
+          curl -L -o ./postgres.tar.gz https://api.github.com/repos/postgres/postgres/tarball/REL_15_STABLE
+          tar -xvf ./postgres.tar.gz
 
       - name: Install pg-bsd-indent
         run: |

--- a/.github/workflows/indent.yml
+++ b/.github/workflows/indent.yml
@@ -23,7 +23,8 @@ jobs:
       - name: Fetch PostgreSQL sources
         run: |
           curl -L -o ./postgres.tar.gz https://api.github.com/repos/postgres/postgres/tarball/REL_15_STABLE
-          tar -xvf ./postgres.tar.gz
+          mkdir postgres
+          tar -xvf ./postgres.tar.gz -C postgres --strip-components 1
 
       - name: Install pg-bsd-indent
         run: |
@@ -34,7 +35,7 @@ jobs:
 
 
       - name: Get headers
-        working-directory: ./postgres
+        working-directory: postgres
         run: wget -O src/tools/pgindent/typedefs.list https://buildfarm.postgresql.org/cgi-bin/typedefs.pl
 
       - name: Get PerlTidy

--- a/expected/uuid_v1_ops.out
+++ b/expected/uuid_v1_ops.out
@@ -1,6 +1,6 @@
 \unset ECHO
 
-1..28
+1..30
 ok 1 - uuid_v1_cmp handles nulls properly
 ok 2 - Less then works fine
 ok 3 - Greater then works fine
@@ -29,3 +29,5 @@ ok 25 - Variant 1
 ok 26 - Variant 2
 ok 27 - Variant 3
 ok 28 - get_variant handles nulls properly
+ok 29 - create_from handles nulls properly
+ok 30 - For some crude timestampts UUID generation is reversible

--- a/sql/uuid_v1_ops.sql
+++ b/sql/uuid_v1_ops.sql
@@ -103,29 +103,29 @@ select is(
         null,
         'create_from handles nulls properly');
 
-/* xxx in principle this is not a strict test, as precision of 
- * the PostgreSQL timestamptz type doesn't match that of the
- * UUID v1 (1usec vs 0.1usec respectively), but if we keep the
- * timestampts rough enough, this should work. Below is a
- * very crude variant of such a test
+/* xxx in principle this is a strict test, as precision of 
+ * the PostgreSQL timestamptz type is lower that that of the
+ * UUID v1 (1usec vs 0.1usec respectively).
+ * Meaning if the UUID was created using this function,
+ * it is inevitably going to be consistently reversible.
  */
 
 with gen as (
-    select  
-            u, 
+    select
+            u,
             uuid_v1_create_from(
-                        uuid_v1_get_timestamptz(u), 
-                        uuid_v1_get_clock_seq(u), 
-                        uuid_v1_get_node_id(u)) as g 
-        from generate_series('2020-10-20 00:00:00 UTC', 
-                             '2020-10-30 00:00:00 UTC', 
-                             interval'20 minutes') as f(x), 
-        uuid_v1_create_from(x, 
+                        uuid_v1_get_timestamptz(u),
+                        uuid_v1_get_clock_seq(u),
+                        uuid_v1_get_node_id(u)) as g
+        from generate_series('2020-10-20 00:00:00 UTC',
+                             '2020-10-30 00:00:00 UTC',
+                             interval'20 minutes') as f(x),
+        uuid_v1_create_from(x,
                             0::int2,
                             macaddr'12:34:56:78:91:12') as g(u)
 ), cnt as(
     select count(*) as c
-        from gen 
+        from gen
         where u != g
 )
 select is(c, 0::int8, 'For some crude timestampts UUID generation is reversible') from cnt;

--- a/sql/uuid_v1_ops.sql
+++ b/sql/uuid_v1_ops.sql
@@ -9,7 +9,7 @@ create extension uuid_v1_ops;
 /* seed random for consistent dataset */
 select setseed(0.2);
 
-select plan(28);
+select plan(30);
 /* tests: */
 
 /* comparison */
@@ -40,15 +40,15 @@ select is(
             true, 
             'Equals works fine');
 select is(
-            uuid_v1_to_timestamptz(uuid'00000000-0000-0000-0000-000000000000') at time zone 'UTC', 
+            uuid_v1_get_timestamptz(uuid'00000000-0000-0000-0000-000000000000') at time zone 'UTC', 
             timestamp'1582-10-15 00:00:00', 
             'Zero-uuid is the start of Gregorian calendar');
 select is(
-            uuid_v1_to_timestamptz(uuid'63b00000-bfde-11d3-0000-000000000000') at time zone 'UTC', 
+            uuid_v1_get_timestamptz(uuid'63b00000-bfde-11d3-0000-000000000000') at time zone 'UTC', 
             timestamp'2000-01-01 00:00:00', 
             'Timestamp of PostgreSQL Epoch');
 select is(
-            uuid_v1_to_timestamptz(uuid'bc2cd750-a63b-11ed-84a2-123456789112') at time zone 'UTC', 
+            uuid_v1_get_timestamptz(uuid'bc2cd750-a63b-11ed-84a2-123456789112') at time zone 'UTC', 
             timestamp'2023-02-06 16:31:40.869', 
             'Some random timestamp');
 
@@ -96,6 +96,39 @@ select is(uuid_v1_get_variant('00000000-0000-1000-8000-000000000000'), 2::int2, 
 select is(uuid_v1_get_variant('00000000-0000-1000-c000-000000000000'), 3::int2,  'Variant 3');
 select is(uuid_v1_get_variant(null), null,  'get_variant handles nulls properly');
 
+/* create_from tests */
+
+select is(
+        uuid_v1_create_from(now(), null, null),
+        null,
+        'create_from handles nulls properly');
+
+/* xxx in principle this is not a strict test, as precision of 
+ * the PostgreSQL timestamptz type doesn't match that of the
+ * UUID v1 (1usec vs 0.1usec respectively), but if we keep the
+ * timestampts rough enough, this should work. Below is a
+ * very crude variant of such a test
+ */
+
+with gen as (
+    select  
+            u, 
+            uuid_v1_create_from(
+                        uuid_v1_get_timestamptz(u), 
+                        uuid_v1_get_clock_seq(u), 
+                        uuid_v1_get_node_id(u)) as g 
+        from generate_series('2020-10-20 00:00:00 UTC', 
+                             '2020-10-30 00:00:00 UTC', 
+                             interval'20 minutes') as f(x), 
+        uuid_v1_create_from(x, 
+                            0::int2,
+                            macaddr'12:34:56:78:91:12') as g(u)
+), cnt as(
+    select count(*) as c
+        from gen 
+        where u != g
+)
+select is(c, 0::int8, 'For some crude timestampts UUID generation is reversible') from cnt;
 
 
 select * from finish();

--- a/src/sql/20_functions.sql
+++ b/src/sql/20_functions.sql
@@ -8,7 +8,7 @@ create or replace function uuid_v1_cmp(uuid, uuid)
 
 create or replace function uuid_v1_get_timestamptz(uuid)
     returns timestamptz
-    language C stable 
+    language C immutable
     parallel safe strict leakproof
     as 'uuid_v1_ops', 'uuid_v1_get_timestamptz';
 

--- a/src/sql/20_functions.sql
+++ b/src/sql/20_functions.sql
@@ -6,11 +6,11 @@ create or replace function uuid_v1_cmp(uuid, uuid)
     parallel safe strict leakproof
     as 'uuid_v1_ops', 'uuid_v1_cmp';
 
-create or replace function uuid_v1_to_timestamptz(uuid)
+create or replace function uuid_v1_get_timestamptz(uuid)
     returns timestamptz
     language C stable 
     parallel safe strict leakproof
-    as 'uuid_v1_ops', 'uuid_v1_to_timestamptz';
+    as 'uuid_v1_ops', 'uuid_v1_get_timestamptz';
 
 create or replace function is_uuid_v1(uuid)
     returns boolean
@@ -62,3 +62,8 @@ create or replace function uuid_v1_get_variant(uuid)
     parallel safe strict leakproof
     as 'uuid_v1_ops', 'uuid_v1_get_variant';
 
+create or replace function uuid_v1_create_from(timestamptz, int2, macaddr)
+    returns uuid
+    language C immutable
+    parallel safe strict leakproof
+    as 'uuid_v1_ops', 'uuid_v1_create_from';

--- a/tap_results/meta.yml
+++ b/tap_results/meta.yml
@@ -2,9 +2,9 @@
 file_attributes:
   -
     description: sql/uuid_v1_ops.sql
-    end_time: 1676325767.44269
-    start_time: 1676325766.84704
+    end_time: 1676384570.275
+    start_time: 1676384569.67915
 file_order:
   - sql/uuid_v1_ops.sql
-start_time: 1676325766
-stop_time: 1676325767
+start_time: 1676384569
+stop_time: 1676384570

--- a/tap_results/sql/uuid_v1_ops.sql
+++ b/tap_results/sql/uuid_v1_ops.sql
@@ -1,4 +1,4 @@
-1..28
+1..30
 ok 1 - uuid_v1_cmp handles nulls properly
 ok 2 - Less then works fine
 ok 3 - Greater then works fine
@@ -27,3 +27,5 @@ ok 25 - Variant 1
 ok 26 - Variant 2
 ok 27 - Variant 3
 ok 28 - get_variant handles nulls properly
+ok 29 - create_from handles nulls properly
+ok 30 - For some crude timestampts UUID generation is reversible

--- a/uuid_v1_ops--0.1.0.sql
+++ b/uuid_v1_ops--0.1.0.sql
@@ -13,11 +13,11 @@ create or replace function uuid_v1_cmp(uuid, uuid)
     parallel safe strict leakproof
     as 'uuid_v1_ops', 'uuid_v1_cmp';
 
-create or replace function uuid_v1_to_timestamptz(uuid)
+create or replace function uuid_v1_get_timestamptz(uuid)
     returns timestamptz
     language C stable 
     parallel safe strict leakproof
-    as 'uuid_v1_ops', 'uuid_v1_to_timestamptz';
+    as 'uuid_v1_ops', 'uuid_v1_get_timestamptz';
 
 create or replace function is_uuid_v1(uuid)
     returns boolean
@@ -69,6 +69,11 @@ create or replace function uuid_v1_get_variant(uuid)
     parallel safe strict leakproof
     as 'uuid_v1_ops', 'uuid_v1_get_variant';
 
+create or replace function uuid_v1_create_from(timestamptz, int2, macaddr)
+    returns uuid
+    language C immutable
+    parallel safe strict leakproof
+    as 'uuid_v1_ops', 'uuid_v1_create_from';
 /* src/sql/025_operators */
 
 create operator ~< (

--- a/uuid_v1_ops.c
+++ b/uuid_v1_ops.c
@@ -152,7 +152,7 @@ uuid_v1_create_from(PG_FUNCTION_ARGS)
 	/*
 	 * Convert PostgreSQL epoch usec timestamptz to the UUID v1 Gregorian
 	 * epoch 0.1usec This can overflow, so we need to be careful
- 	 */
+	 */
 
 	if (((PG_INT64_MAX / UUID_V1_100NS_TO_USEC) - ts) < GREGORIAN_BEGINNING_OFFSET_USEC)
 	{

--- a/uuid_v1_ops.c
+++ b/uuid_v1_ops.c
@@ -142,17 +142,17 @@ uuid_v1_get_variant(PG_FUNCTION_ARGS)
 Datum
 uuid_v1_create_from(PG_FUNCTION_ARGS)
 {
-	TimestampTz	ts 			= PG_GETARG_TIMESTAMPTZ(0);
-	int16		clock_seq 	= PG_GETARG_INT16(1);
-	macaddr		*node 		= PG_GETARG_MACADDR_P(2);
-	pg_uuid_t	*res;
-	
+	TimestampTz ts = PG_GETARG_TIMESTAMPTZ(0);
+	int16		clock_seq = PG_GETARG_INT16(1);
+	macaddr    *node = PG_GETARG_MACADDR_P(2);
+	pg_uuid_t  *res;
+
 	res = (pg_uuid_t *) palloc(sizeof(*res));
 
-	/* Convert PostgreSQL epoch usec timestamptz to
-	 * the UUID v1 Gregorian epoch 0.1usec 
-	 * This can overflow, so we need to be careful
-	 */
+	/*
+	 * Convert PostgreSQL epoch usec timestamptz to the UUID v1 Gregorian
+	 * epoch 0.1usec This can overflow, so we need to be careful
+ 	 */
 
 	if (((PG_INT64_MAX / UUID_V1_100NS_TO_USEC) - ts) < GREGORIAN_BEGINNING_OFFSET_USEC)
 	{
@@ -162,39 +162,39 @@ uuid_v1_create_from(PG_FUNCTION_ARGS)
 	}
 
 	ts = (ts + GREGORIAN_BEGINNING_OFFSET_USEC) * UUID_V1_100NS_TO_USEC;
-	
+
 	/* We try to keep further modifications endiannes-neutral */
 
 	/* timestamp low bytes */
-	res->data[0]	= (uint8) ((ts & 0xff000000) >> 24);
-	res->data[1]	= (uint8) ((ts & 0xff0000) >> 16);
-	res->data[2]	= (uint8) ((ts & 0xff00) >> 8);
-	res->data[3]	= (uint8) ((ts & 0xff));
+	res->data[0] = (uint8) ((ts & 0xff000000) >> 24);
+	res->data[1] = (uint8) ((ts & 0xff0000) >> 16);
+	res->data[2] = (uint8) ((ts & 0xff00) >> 8);
+	res->data[3] = (uint8) ((ts & 0xff));
 
 	/* timestamp mid bytes */
-	res->data[4]	= (uint8) ((ts & 0xff0000000000) >> 40);
-	res->data[5]	= (uint8) ((ts & 0xff00000000) >> 32);
+	res->data[4] = (uint8) ((ts & 0xff0000000000) >> 40);
+	res->data[5] = (uint8) ((ts & 0xff00000000) >> 32);
 
 	/* timestamp hi bytes and version */
-	res->data[6]	= (uint8) ((ts & 0x0f00000000000000) >> 56);
+	res->data[6] = (uint8) ((ts & 0x0f00000000000000) >> 56);
 	/* append version to the upper MSB of timestamp hi */
-	res->data[6]	|= (1 << 4);
-	res->data[7]	= (uint8) ((ts & 0xff000000000000) >> 48);
+	res->data[6] |= (1 << 4);
+	res->data[7] = (uint8) ((ts & 0xff000000000000) >> 48);
 
 	/* clock seq hi and reserved */
-	res->data[8]	= (uint8) ((clock_seq & 0x3f00) >> 8);
+	res->data[8] = (uint8) ((clock_seq & 0x3f00) >> 8);
 	/* append reserver to the clock seq high */
-	res->data[8]	|= 0x80;
+	res->data[8] |= 0x80;
 	/* clock seq low */
-	res->data[9]	= (uint8) (clock_seq & 0xff);
+	res->data[9] = (uint8) (clock_seq & 0xff);
 
 	/* node id */
-	res->data[10]	= node->a;
-	res->data[11]	= node->b;
-	res->data[12]	= node->c;
-	res->data[13]	= node->d;
-	res->data[14]	= node->e;
-	res->data[15]	= node->f;
+	res->data[10] = node->a;
+	res->data[11] = node->b;
+	res->data[12] = node->c;
+	res->data[13] = node->d;
+	res->data[14] = node->e;
+	res->data[15] = node->f;
 
 	PG_RETURN_UUID_P(res);
 }

--- a/uuid_v1_ops.h
+++ b/uuid_v1_ops.h
@@ -34,8 +34,8 @@ Datum		uuid_v1_cmp(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(uuid_v1_internalize);
 Datum		uuid_v1_internalize(PG_FUNCTION_ARGS);
 
-PG_FUNCTION_INFO_V1(uuid_v1_to_timestamptz);
-Datum		uuid_v1_to_timestamptz(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(uuid_v1_get_timestamptz);
+Datum		uuid_v1_get_timestamptz(PG_FUNCTION_ARGS);
 
 PG_FUNCTION_INFO_V1(uuid_v1_lt);
 Datum		uuid_v1_lt(PG_FUNCTION_ARGS);
@@ -60,6 +60,10 @@ Datum		uuid_v1_get_clock_seq(PG_FUNCTION_ARGS);
 
 PG_FUNCTION_INFO_V1(uuid_v1_get_variant);
 Datum		uuid_v1_get_variant(PG_FUNCTION_ARGS);
+
+PG_FUNCTION_INFO_V1(uuid_v1_create_from);
+Datum		uuid_v1_create_from(PG_FUNCTION_ARGS);
+
 
 static int	uuid_v1_internal_cmp(const pg_uuid_t *arg1, const pg_uuid_t *arg2);
 


### PR DESCRIPTION
Addressing #14 
- Support creation of UUID v1 from supplied parameters
- Rename to_timestmptz function to be more consistent with its counterparts
- Improve speed of pgindent test by fetching tarball instead of issuing a `git clone`