### PR TITLE
try pgxn_container and update job name for pgindent

### DIFF
--- a/.github/workflows/indent.yml
+++ b/.github/workflows/indent.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  pgindent:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build and Test
-        run: make && sudo -E make install && make installcheck
+        run: pg-build-test
 
       - name: Show regression diffs
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,3 @@ jobs:
 
       - name: Build and Test
         run: pg-build-test
-
-      - name: Show regression diffs
-        if: always()
-        run: cat regression.diffs || true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build and Test
-        run: make && sudo -E make install && time make installcheck
+        run: make && sudo -E make install && make installcheck
 
       - name: Show regression diffs
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,33 +9,17 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    container: pgxn/pgxn-tools
     strategy:
       matrix:
         postgresql-version: [11, 12, 13, 14, 15]
 
-    env:
-      PG:       ${{ matrix.postgresql-version }}
-
     steps:
+      - name: Start PostgreSQL ${{ matrix.pg }}
+        run: pg-start ${{ matrix.postgresql-version }}
+
       - name: Checkout code
         uses: actions/checkout@v3
-      
-      - name: Initialize the env before installing Postgres
-        run: |
-          sudo apt-get -y --purge --no-upgrade remove postgresql libpq-dev libpq5 postgresql-client-common postgresql-common
-          sudo apt install curl ca-certificates gnupg
-          curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg >/dev/null
-          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-          sudo apt-get update -qq
-          sudo rm -rf /var/lib/postgresql
-      
-      - name: Install PostgreSQL
-        run: |
-          sudo apt-get -y \
-                -o Dpkg::Options::=--force-confdef \
-                -o Dpkg::Options::=--force-confnew \
-                install postgresql-${PG:?} postgresql-server-dev-${PG:?}
-          sudo -u postgres createuser -s "$USER"
 
       - name: Build and Test
         run: make && sudo -E make install && time make installcheck


### PR DESCRIPTION
This version of tests uses pgxn container. This shaves off some 10 seconds from test times. The disadvantage is the less transparent nature of tests.
Probably not worth it.